### PR TITLE
Use pysnmp for SNMP operations with bulk and async helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 import re, csv, io, time
+from concurrent.futures import ThreadPoolExecutor
 from flask import Flask, render_template, request, redirect, url_for, abort, Response, flash
 from models import db, ensure_db
 from snmp import (
-    snmpwalk, snmpset, first_int, first_str,
+    snmpwalk, snmpwalk_bulk, snmpset, first_int, first_str,
     OID_IFNAME, OID_IF_DESCR, OID_IF_ALIAS, OID_IF_OPER_STATUS, OID_IF_ADMIN_STATUS,
     OID_IF_IN_5M_BIT, OID_IF_OUT_5M_BIT,
     OID_GPON_BIND_SN, OID_GPON_STATUS, OID_GPON_ONU_RX, OID_GPON_ONU_TX,
@@ -172,15 +173,24 @@ def olt_device(ip):
         row = conn.execute("SELECT hostname, community FROM olts WHERE ip = ?", (ip,)).fetchone()
         if not row: abort(404)
         hostname, community = row
-    sys_name   = first_str(snmpwalk(ip, community, OID_SYS_NAME))
-    sys_loc    = first_str(snmpwalk(ip, community, OID_SYS_LOCATION))
-    sys_cont   = first_str(snmpwalk(ip, community, OID_SYS_CONTACT))
-    sys_descr  = first_str(snmpwalk(ip, community, OID_SYS_DESCR))
-    sys_time   = first_str(snmpwalk(ip, community, OID_SYS_TIME_STR))
-    uptime     = get_sys_uptime_ticks(ip, community)
-    cpu        = get_cpu_percent(ip, community)
-    mem        = first_int(snmpwalk(ip, community, OID_MEM_USAGE))
-    temp       = first_int(snmpwalk(ip, community, OID_TEMP_BOARD))
+    bulk_oids = [
+        OID_SYS_NAME, OID_SYS_LOCATION, OID_SYS_CONTACT,
+        OID_SYS_DESCR, OID_SYS_TIME_STR, OID_MEM_USAGE, OID_TEMP_BOARD,
+    ]
+    with ThreadPoolExecutor() as ex:
+        fut_bulk = ex.submit(snmpwalk_bulk, ip, community, bulk_oids)
+        fut_uptime = ex.submit(get_sys_uptime_ticks, ip, community)
+        fut_cpu = ex.submit(get_cpu_percent, ip, community)
+        bulk_res = fut_bulk.result()
+        uptime = fut_uptime.result()
+        cpu = fut_cpu.result()
+    sys_name   = first_str(bulk_res.get(OID_SYS_NAME))
+    sys_loc    = first_str(bulk_res.get(OID_SYS_LOCATION))
+    sys_cont   = first_str(bulk_res.get(OID_SYS_CONTACT))
+    sys_descr  = first_str(bulk_res.get(OID_SYS_DESCR))
+    sys_time   = first_str(bulk_res.get(OID_SYS_TIME_STR))
+    mem        = first_int(bulk_res.get(OID_MEM_USAGE))
+    temp       = first_int(bulk_res.get(OID_TEMP_BOARD))
     return render_template("olt_device.html",
                            ip=ip, hostname=hostname,
                            sys_name=sys_name, sys_loc=sys_loc, sys_cont=sys_cont,
@@ -197,10 +207,11 @@ def olt_uplinks(ip):
         if not row: abort(404)
         hostname, community = row
 
-    names  = snmpwalk(ip, community, OID_IFNAME)
-    descrs = snmpwalk(ip, community, OID_IF_DESCR)
-    alias  = snmpwalk(ip, community, OID_IF_ALIAS)
-    status = snmpwalk(ip, community, OID_IF_OPER_STATUS)
+    bulk_if = snmpwalk_bulk(ip, community, [OID_IFNAME, OID_IF_DESCR, OID_IF_ALIAS, OID_IF_OPER_STATUS])
+    names  = bulk_if.get(OID_IFNAME, [])
+    descrs = bulk_if.get(OID_IF_DESCR, [])
+    alias  = bulk_if.get(OID_IF_ALIAS, [])
+    status = bulk_if.get(OID_IF_OPER_STATUS, [])
 
     def parse_map(pattern, lines):
         m = {}
@@ -247,9 +258,18 @@ def port(ip, ifindex):
             (ip, ifindex)
         ).fetchall()
         comm = conn.execute("SELECT community FROM olts WHERE ip = ?", (ip,)).fetchone()[0]
-    tx = first_int(snmpwalk(ip, comm, f"{OID_PON_PORT_TX}.{ifindex}"))
-    rx = first_int(snmpwalk(ip, comm, f"{OID_PON_PORT_RX}.{ifindex}"))
-    stat = first_int(snmpwalk(ip, comm, f"{OID_IF_OPER_STATUS}.{ifindex}"))
+    bulk = snmpwalk_bulk(
+        ip,
+        comm,
+        [
+            f"{OID_PON_PORT_TX}.{ifindex}",
+            f"{OID_PON_PORT_RX}.{ifindex}",
+            f"{OID_IF_OPER_STATUS}.{ifindex}",
+        ],
+    )
+    tx = first_int(bulk.get(f"{OID_PON_PORT_TX}.{ifindex}"))
+    rx = first_int(bulk.get(f"{OID_PON_PORT_RX}.{ifindex}"))
+    stat = first_int(bulk.get(f"{OID_IF_OPER_STATUS}.{ifindex}"))
     def dbm(x): return None if x is None else x/10.0
     return render_template("port_onus.html",
                            ip=ip, port_name=port_name, ifindex=ifindex, onus=onus,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 Flask==3.0.2
+
+# SNMP library
+pysnmp==4.4.12

--- a/snmp.py
+++ b/snmp.py
@@ -1,27 +1,122 @@
 import re
-import subprocess
-from typing import Optional, List
+from typing import Optional, List, Iterable, Dict
 
-# Используем snmpbulkwalk + стабильный вывод и «продолжение» при OID not increasing.
-SNMP_WALK_CMD  = "snmpbulkwalk"
-SNMP_WALK_OPTS = ["-v2c", "-On", "-OXs", "-Cc", "-Cr50"]  # числовые OID, компактные типы, continue, bulk
-SNMP_SET_OPTS  = ["-v2c", "-On", "-OXs"]                  # set: формат не критичен, но пусть будет единый
+from pysnmp.hlapi import (
+    SnmpEngine, CommunityData, UdpTransportTarget, ContextData,
+    ObjectType, ObjectIdentity, bulkCmd, setCmd
+)
+from pysnmp.proto.rfc1902 import (
+    Integer, OctetString, TimeTicks, Counter32, Gauge32,
+    IpAddress, Unsigned32, ObjectIdentifier
+)
+
+
+def _fmt_value(val) -> str:
+    """Convert pysnmp value to net-snmp-like text representation."""
+    if isinstance(val, OctetString):
+        return f'STRING: "{val.prettyPrint()}"'
+    if isinstance(val, TimeTicks):
+        return f'Timeticks: ({int(val)})'
+    if isinstance(val, Counter32):
+        return f'Counter32: {int(val)}'
+    if isinstance(val, Gauge32):
+        return f'Gauge32: {int(val)}'
+    if isinstance(val, Unsigned32):
+        return f'Unsigned32: {int(val)}'
+    if isinstance(val, IpAddress):
+        return f'IpAddress: {val.prettyPrint()}'
+    if isinstance(val, Integer):
+        return f'INTEGER: {int(val)}'
+    if isinstance(val, ObjectIdentifier):
+        return f'OID: {val.prettyPrint()}'
+    return val.prettyPrint()
+
 
 def snmpwalk(host: str, community: str, oid: str, timeout=2) -> list[str]:
-    cmd = [SNMP_WALK_CMD, *SNMP_WALK_OPTS, "-c", community, "-t", str(timeout), host, oid]
-    out = subprocess.run(cmd, capture_output=True, text=True)
-    # Даже если stderr содержит предупреждение, stdout нам важнее
-    txt = (out.stdout or "").strip()
-    return [ln.rstrip() for ln in txt.splitlines() if ln.strip()]
+    """Walk single OID subtree using pysnmp without spawning processes."""
+    engine = SnmpEngine()
+    target = UdpTransportTarget((host, 161), timeout=timeout)
+    obj = ObjectType(ObjectIdentity(oid))
+    res: List[str] = []
+    for (errInd, errStat, errIdx, varBinds) in bulkCmd(
+        engine,
+        CommunityData(community, mpModel=1),
+        target,
+        ContextData(),
+        0, 25,
+        obj,
+        lexicographicMode=False,
+    ):
+        if errInd or errStat:
+            break
+        for vb in varBinds:
+            res.append(f"{vb[0].prettyPrint()} = {_fmt_value(vb[1])}")
+    return res
+
+
+def snmpwalk_bulk(host: str, community: str, oids: Iterable[str], timeout=2) -> Dict[str, List[str]]:
+    """Fetch several OID trees in a single bulk request."""
+    engine = SnmpEngine()
+    target = UdpTransportTarget((host, 161), timeout=timeout)
+    obj_types = [ObjectType(ObjectIdentity(o)) for o in oids]
+    res: Dict[str, List[str]] = {o: [] for o in oids}
+    for (errInd, errStat, errIdx, varBinds) in bulkCmd(
+        engine,
+        CommunityData(community, mpModel=1),
+        target,
+        ContextData(),
+        0, 25,
+        *obj_types,
+        lexicographicMode=False,
+    ):
+        if errInd or errStat:
+            break
+        for vb in varBinds:
+            oid_str = vb[0].prettyPrint()
+            line = f"{oid_str} = {_fmt_value(vb[1])}"
+            for base in res:
+                if oid_str.startswith(base):
+                    res[base].append(line)
+                    break
+    return res
+
 
 def snmpset(host: str, community: str, oid: str, typechar: str, value: str, timeout=2) -> bool:
-    """
-    Выполнить SNMP SET через net-snmp. typechar: i,u,t,a,o,x,d,b,s,…
-    Пример: snmpset(ip, comm, f"{OID_IF_ADMIN_STATUS}.117", "i", "2")
-    """
-    cmd = ["snmpset", *SNMP_SET_OPTS, "-c", community, "-t", str(timeout), host, oid, typechar, value]
-    out = subprocess.run(cmd, capture_output=True, text=True)
-    return out.returncode == 0
+    """Perform SNMP SET using pysnmp. typechar: i,u,t,a,o,s,…"""
+    typechar = (typechar or '').lower()
+    tmap = {
+        'i': Integer,
+        'u': Unsigned32,
+        't': TimeTicks,
+        'a': IpAddress,
+        'o': ObjectIdentifier,
+        's': OctetString,
+        'x': OctetString,
+        'd': OctetString,
+        'b': OctetString,
+    }
+    cls = tmap.get(typechar, OctetString)
+    try:
+        if cls in (Integer, Unsigned32, TimeTicks):
+            val_obj = cls(int(value))
+        elif cls is IpAddress:
+            val_obj = cls(value)
+        elif cls is ObjectIdentifier:
+            val_obj = cls(value)
+        else:
+            val_obj = cls(value)
+    except Exception:
+        return False
+    errorIndication, errorStatus, errorIndex, varBinds = next(
+        setCmd(
+            SnmpEngine(),
+            CommunityData(community, mpModel=1),
+            UdpTransportTarget((host, 161), timeout=timeout),
+            ContextData(),
+            ObjectType(ObjectIdentity(oid), val_obj)
+        )
+    )
+    return not errorIndication and errorStatus == 0
 
 def parse_uptime_ticks(lines: List[str]) -> Optional[int]:
     if not lines:


### PR DESCRIPTION
## Summary
- replace net-snmp subprocess calls with pysnmp-based helpers
- add bulk OID retrieval and async SNMP calls to reduce process spawns
- group interface and port metrics into single walk requests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pysnmp==4.4.12)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689dab6638748324939b6a2b327c4cd0