### PR TITLE
Avoid redundant schema migrations

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,17 +1,25 @@
 import sqlite3, pathlib, contextlib
 
 BASE = pathlib.Path(__file__).resolve().parent
-DB   = BASE / "instance" / "onulist.db"
+DB = BASE / "instance" / "onulist.db"
 SCHEMA = BASE / "schema.sql"
+SCHEMA_VERSION = 1
+
 
 def ensure_db():
     DB.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(DB) as conn, open(SCHEMA,"r") as f:
-        conn.executescript(f.read())
+    with sqlite3.connect(DB) as conn:
+        cur = conn.cursor()
+        version = cur.execute("PRAGMA user_version").fetchone()[0]
+        if version != SCHEMA_VERSION:
+            with open(SCHEMA, "r") as f:
+                cur.executescript(f.read())
+            cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+
 
 @contextlib.contextmanager
 def db():
-    ensure_db()
     conn = sqlite3.connect(DB)
     try:
         yield conn


### PR DESCRIPTION
## Summary
- Track database schema with `PRAGMA user_version`
- Run migrations only when version changes and remove repeated checks

## Testing
- `python -m py_compile models.py app.py`
- `python - <<'PY'
from models import ensure_db, DB
ensure_db()
import sqlite3
with sqlite3.connect(DB) as conn:
    print('user_version', conn.execute('PRAGMA user_version').fetchone()[0])
PY`


------
https://chatgpt.com/codex/tasks/task_e_689dab632b58832481750dc4e2c9d835